### PR TITLE
Use fetch and regular json for api interactions

### DIFF
--- a/web/routes.go
+++ b/web/routes.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"embed"
-	"encoding/base64"
-	"errors"
 	"html/template"
 	"io/fs"
 	"log"
@@ -32,53 +30,6 @@ func AttachWebRoutes(e *gin.Engine) {
 	log.Println("using embedded files - rebuild to get changes")
 
 	e.GET("/", func(c *gin.Context) {
-		res, err := getWithdrawRes(c)
-		if err != nil && !errors.Is(err, http.ErrNoCookie) {
-			c.SetCookie("withdrawError", "", 0, "", "", true, true)
-			c.SetCookie("withdrawSuccess", "", 0, "", "", true, true)
-			c.AbortWithStatus(http.StatusInternalServerError)
-			return
-		}
-		c.HTML(http.StatusOK, "index.gohtml", gin.H{
-			"error":   res.errMsg,
-			"success": res.success,
-		})
+		c.HTML(http.StatusOK, "index.gohtml", gin.H{})
 	})
-}
-
-type withdrawResult struct {
-	errMsg, success string
-}
-
-func getWithdrawRes(c *gin.Context) (withdrawResult, error) {
-	var errMsg, success string
-	eCookie, err := c.Request.Cookie("withdrawError")
-	switch err {
-	case http.ErrNoCookie:
-	case nil:
-		msg, decodeErr := base64.StdEncoding.DecodeString(eCookie.Value)
-		if decodeErr != nil {
-			log.Printf("b64 decode error: %v\n", decodeErr)
-		}
-		errMsg = string(msg)
-	default:
-		return withdrawResult{}, err
-	}
-
-	eCookie, err = c.Request.Cookie("withdrawSuccess")
-	switch err {
-	case http.ErrNoCookie:
-	case nil:
-		msg, decodeErr := base64.StdEncoding.DecodeString(eCookie.Value)
-		if decodeErr != nil {
-			log.Printf("b64 decode error: %v\n", decodeErr)
-		}
-		success = string(msg)
-	default:
-		return withdrawResult{}, err
-	}
-	return withdrawResult{
-		errMsg,
-		success,
-	}, err
 }

--- a/web/templates/index.gohtml
+++ b/web/templates/index.gohtml
@@ -9,13 +9,8 @@
 <h1 class="logo">
   ATillM
 </h1>
-{{ if gt (len .error) 0 }}
-<div class="error">{{ .error }}</div>
-{{ end }}
-{{ if gt (len .success) 0 }}
-  <div class="success">{{ .success }}</div>
-{{ end }}
-<form action="/api/withdraw" method="post">
+<div class="message">&nbsp;</div>
+<form id="withdraw" action="/api/withdraw" method="post">
   <label for="pan">Personal Account Number</label>
   <input type="text" id="pan" name="pan" pattern="\d+" required />
   <label for="amount">Amount</label>
@@ -25,5 +20,28 @@
 <form action="/api/reset" method="post">
   <button type="submit">Time travel to tomorrow</button>
 </form>
+<script>
+  const handleSubmit = async (e) => {
+      e.preventDefault();
+      const messageNode = document.querySelector('.message');
+      fetch('/api/withdraw', {
+          method: 'POST',
+          mode: 'cors',
+          credentials: 'same-origin',
+          body: new FormData(document.forms['withdraw'])
+      }).then(async (res) => {
+          const data = await res.json();
+          messageNode.textContent = data.message;
+          messageNode.classList.add(res.ok ? 'success' : 'error');
+          messageNode.classList.remove(!res.ok ? 'success' : 'error');
+          if (res.ok) {
+              document.forms['withdraw'].reset();
+          }
+      }, async (err) => {
+          console.error(err);
+      });
+  }
+  document.forms['withdraw'].addEventListener('submit', handleSubmit);
+</script>
 </body>
 </html>


### PR DESCRIPTION
- Doing it without JS was fun, but we can use a tiny bit of built-in functionality to do all
of what we need and avoid cookie shenanigans